### PR TITLE
Fix path to git src in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In order to add an deployment marker, a revision number and a description may be
 For this purpose provide a `git` resource in the put step so that New Relic concourse resource
 takes the **revision**  from `(SHA of origin/HEAD commit)` and **description** from `(Commit message of origin/HEAD commit)`.
 
-* `git_src_directory`: *Required.* source code of the deployed version. Format is `/tmp/put/build/<<name of git resource>>`
+* `git_src_directory`: *Required.* source code of the deployed version. Format is `/tmp/build/put/<<name of git resource>>`
 * `api_url`: *Mandatory.* Deployment [REST api endpoint](https://rpm.newrelic.com/api/explore/application_deployments/create)  
 * `app_id`: *Optional* (`deprecated` in favour of api_url) Application ID from New Relic, if `api_url` is not provided this defaults to **US API endpoint**
 


### PR DESCRIPTION
Hey Shyam :)

Great work on the resource!
Noticed one minor thing:
In your README, you seem to have accidentally put `/tmp/put/build` instead of `/tmp/build/put` so I fixed it for you.

Sunny greetings from SDC Lisbon and have a great day🌞